### PR TITLE
Release 3.2.3-1, updated zabbix-monitoring-scripts and included docker-host-monitoring package in the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Build Digia Pulssi specific Zabbix Agent installation packages. The changes intr
 
 Download the latest installation packages from https://github.com/digiapulssi/zabbix-agent/releases/latest
 
-- CentOS / RedHat / Oracle Linux 5.x: zabbix-agent-VERSION.digiapulssi.el5.x86_64.rpm
-- CentOS / RedHat / Oracle Linux 6.x: zabbix-agent-VERSION.digiapulssi.el6.x86_64.rpm
-- CentOS / RedHat / Oracle Linux 7.x: zabbix-agent-VERSION.digiapulssi.el7.x86_64.rpm
-- Debian 7 (Wheezy): zabbix-agent_VERSION.digiapulssi.wheezy-1_amd64.deb
-- Debian 8 (Jessie): zabbix-agent_VERSION.digiapulssi.jessie-1_amd64.deb
+- CentOS / RedHat / Oracle Linux 5.x: zabbix-agent-pulssi-VERSION.el5.x86_64.rpm
+- CentOS / RedHat / Oracle Linux 6.x: zabbix-agent-pulssi-VERSION.el6.x86_64.rpm
+- CentOS / RedHat / Oracle Linux 7.x: zabbix-agent-pulssi-VERSION.el7.x86_64.rpm
+- Debian 7 (Wheezy): zabbix-agent-pulssi_VERSION.wheezy-1_amd64.deb
+- Debian 8 (Jessie): zabbix-agent-pulssi_VERSION.jessie-1_amd64.deb
 
 # Installation and Configuration
 
@@ -26,7 +26,7 @@ Download the latest installation packages from https://github.com/digiapulssi/za
 Install the downloaded RPM package with the following command:
 
 ```
-yum localinstall zabbix-agent-VERSION.digiapulssi.DISTRIBUTION.x86_64.rpm
+yum localinstall zabbix-agent-pulssi-VERSION.DISTRIBUTION.x86_64.rpm
 (for CentOS/RedHat/Oracle Linux 5.x you need to add --nogpgcheck flag)
 ```
 
@@ -42,7 +42,7 @@ chkconfig zabbix-agent on
 Install the downloaded DEB package with the following command:
 
 ```
-gdebi zabbix-agent_VERSION.digiapulssi.DISTRIBUTION-1_amd64.deb
+gdebi zabbix-agent-pulssi_VERSION.DISTRIBUTION-1_amd64.deb
 ```
 
 Make the configuration changes (see below), and restart the agent:

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ The packaging has been adapted from the instructions at http://zabbix.org/wiki/D
 
 Environment variables controlling the versions are defined in Dockerfile.* files.
 
-PULSSI_RELEASE_VERSION environment variable defines Digia Pulssi subversion number in case we want to release
-multiple versions of a single Zabbix Agent version&release.
+PULSSI_RELEASE_VERSION environment variable defines Digia Pulssi release/build number
+eg. 3.2.3-PULSSI_RELEASE_VERSION.
 
 To release a package based on a newer Zabbix Agent version:
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,12 @@ all the files in the directory are considered as actual configuration files and 
 
 # How to Release a New Version (for Digia Pulssi Developers)
 
-Run the release script in the repository root directory:
+Update PULSSI_RELEASE_VERSION in Dockerfile files (see below).
+
+Run the build script in the repository root directory:
 
 ```
-./release.sh
+./build-all.sh
 ```
 
 After building the release, create a new release in Github and upload the packages there.

--- a/build-all.sh
+++ b/build-all.sh
@@ -29,10 +29,12 @@ pushd debian
 # First build the package creation containers locally
 docker build -t zabbix-deb:debian7 -f Dockerfile.debian7 .
 docker build -t zabbix-deb:debian8 -f Dockerfile.debian8 .
+docker build -t zabbix-deb:debian8docker -f Dockerfile.debian8.docker-host-monitoring .
 
 # Then run the following commands to produce new installation packages for different platforms
 docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian7
 docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian8
+docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian8docker
 
 popd
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -17,10 +17,10 @@ docker run --rm -v $(pwd)/RPMS:/root/rpmbuild/RPMS zabbix-rpm:centos6
 docker run --rm -v $(pwd)/RPMS:/root/rpmbuild/RPMS zabbix-rpm:centos7
 
 # Modify CentOS 5 package name to include "el5" tag similarly to the others
-sudo rename 's/zabbix-agent-([0-9.-]+)\.digiapulssi\.x86_64\.rpm/zabbix-agent-$1.digiapulssi.el5.x86_64.rpm/' RPMS/x86_64/*.rpm
+sudo rename 's/zabbix-agent-pulssi-([0-9.-]+)\.x86_64\.rpm/zabbix-agent-pulssi-$1.el5.x86_64.rpm/' RPMS/x86_64/*.rpm
 
 # Remove "centos" from CentOS 7 package name
-sudo rename 's/zabbix-agent-([0-9.-]+)\.digiapulssi\.el7\.centos\.x86_64\.rpm/zabbix-agent-$1.digiapulssi.el7.x86_64.rpm/' RPMS/x86_64/*.rpm
+sudo rename 's/zabbix-agent-pulssi-([0-9.-]+)\.el7\.centos\.x86_64\.rpm/zabbix-agent-pulssi-$1.el7.x86_64.rpm/' RPMS/x86_64/*.rpm
 
 popd
 

--- a/debian/Dockerfile.debian7
+++ b/debian/Dockerfile.debian7
@@ -18,5 +18,5 @@ RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
 ENV ZABBIX_VERSION=3.2.3
 ENV ZABBIX_BRANCH=branch-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=0
+ENV PULSSI_RELEASE_VERSION=1
 ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.2/debian/pool/main/z/zabbix/zabbix_3.2.3-1+wheezy.dsc

--- a/debian/Dockerfile.debian8.docker-host-monitoring
+++ b/debian/Dockerfile.debian8.docker-host-monitoring
@@ -17,6 +17,6 @@ COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
 ENV ZABBIX_VERSION=3.2.3
-ENV ZABBIX_BRANCH=branch-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=1
+ENV ZABBIX_BRANCH=docker-host-monitoring
+ENV PULSSI_RELEASE_VERSION=1.docker-host-monitoring
 ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.2/debian/pool/main/z/zabbix/zabbix_3.2.3-1+jessie.dsc

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -34,14 +34,22 @@ cd zabbix-$ZABBIX_VERSION
 # Update the source package with our latest build
 
 # Get the current version number (like 1:3.2.3-1+wheezy)
-# and add digiapulssi to the Release number (like 1:3.2.3-1.X.digiapulssi+wheezy)
-#   X ($PULSSI_RELEASE_VERSION) defines Pulssi subversion number in case we want to release
-#                               multiple versions of a single Zabbix Agent version&release
+# and update the Release/build number (like 1:3.2.3-X+wheezy)
 CURRENT_VERSION=$(dpkg-parsechangelog | sed -n 's/^Version: //p')
-NEW_VERSION=$(echo "$CURRENT_VERSION" | sed -e 's/^\(.*\)+\(.*\)$/\1.'${PULSSI_RELEASE_VERSION}'.digiapulssi+\2/')
+NEW_VERSION=$(echo "$CURRENT_VERSION" | sed -e 's/^\(.*\)-[0-9]\++\(.*\)$/\1-'${PULSSI_RELEASE_VERSION}'+\2/')
 
-uupdate "$BUILDDIR/zabbix-$ZABBIX_VERSION/zabbix-$ZABBIX_VERSION.tar.gz" -v "$NEW_VERSION"
-cd ../zabbix-*digiapulssi*
+UUPDATE_OUT=$(uupdate "$BUILDDIR/zabbix-$ZABBIX_VERSION/zabbix-$ZABBIX_VERSION.tar.gz" -v "$NEW_VERSION")
+echo "$UUPDATE_OUT"
+
+# uupdate tells the new directory name in its standard output
+#    Do a "cd ../zabbix-3.2.3-1+wheezy" to see the new package
+NEW_DIR=$(echo "$UUPDATE_OUT" | sed -n 's/Do a "cd \(.*\)" to see the new package/\1/p')
+cd "$NEW_DIR"
+
+# Change zabbix-agent package name to zabbix-agent-pulssi
+sed -i 's/^Package: zabbix-agent$/Package: zabbix-agent-pulssi/' debian/control
+sed -i 's/dh_installinit -p zabbix-agent/dh_installinit -p zabbix-agent-pulssi/' debian/rules
+rename 's/zabbix-agent\.(.*)$/zabbix-agent-pulssi.$1/' debian/zabbix-agent.*
 
 # Default configuration changes
 # Do not specify Hostname but use system hostname by default
@@ -61,16 +69,16 @@ popd
 ##############################################################33
 # Monitoring scripts under /etc/zabbix/scripts
 
-echo "etc/zabbix/scripts" >> debian/zabbix-agent.dirs
+echo "etc/zabbix/scripts" >> debian/zabbix-agent-pulssi.dirs
 
 # Add each script file individually to files section
 for scriptpath in zabbix-monitoring-scripts/scripts/*; do
    scriptfile=$(basename $scriptpath)
-   echo "zabbix-monitoring-scripts/scripts/$scriptfile etc/zabbix/scripts" >> debian/zabbix-agent.install
+   echo "zabbix-monitoring-scripts/scripts/$scriptfile etc/zabbix/scripts" >> debian/zabbix-agent-pulssi.install
 done
 
 # Executable rights in post-install script
-sed -i -e '/configure/a \    chmod 755 /etc/zabbix/scripts/*' debian/zabbix-agent.postinst
+sed -i -e '/configure/a \    chmod 755 /etc/zabbix/scripts/*' debian/zabbix-agent-pulssi.postinst
 
 ##############################################################33
 # Monitoring script configuration files under /etc/zabbix/zabbix_agentd.d
@@ -78,7 +86,7 @@ sed -i -e '/configure/a \    chmod 755 /etc/zabbix/scripts/*' debian/zabbix-agen
 # Add each configuration file individually to files section
 for confpath in zabbix-monitoring-scripts/zabbix_agentd.d/*; do
    conffile=$(basename $confpath)
-   echo "zabbix-monitoring-scripts/zabbix_agentd.d/$conffile etc/zabbix/zabbix_agentd.d" >> debian/zabbix-agent.install
+   echo "zabbix-monitoring-scripts/zabbix_agentd.d/$conffile etc/zabbix/zabbix_agentd.d" >> debian/zabbix-agent-pulssi.install
 done
 
 # Add our packaging modifications in
@@ -88,4 +96,4 @@ EDITOR=/bin/true dpkg-source --commit . digiapulssi-packaging-changes
 debuild -us -uc
 
 # Copy debian files under /DEB volume mount
-cp ../zabbix-agent*.deb /DEB/
+cp ../zabbix-agent-pulssi*.deb /DEB/

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -50,10 +50,13 @@ sed -i '/^Hostname=Zabbix server/d' conf/zabbix_agentd.conf
 sed -i '/^# Timeout=3/a Timeout=15' conf/zabbix_agentd.conf
 
 # Get Pulssi monitoring scripts
+mkdir zabbix-monitoring-scripts
+pushd zabbix-monitoring-scripts
 wget https://github.com/digiapulssi/zabbix-monitoring-scripts/tarball/master
-tar --wildcards -zxvf master */scripts --strip 1
-tar --wildcards -zxvf master */config --strip 1
+tar --wildcards -zxvf master */etc/zabbix/scripts --strip 3
+tar --wildcards -zxvf master */etc/zabbix/zabbix_agentd.d --strip 3
 rm -f master
+popd
 
 ##############################################################33
 # Monitoring scripts under /etc/zabbix/scripts
@@ -61,9 +64,9 @@ rm -f master
 echo "etc/zabbix/scripts" >> debian/zabbix-agent.dirs
 
 # Add each script file individually to files section
-for scriptpath in scripts/*; do
+for scriptpath in zabbix-monitoring-scripts/scripts/*; do
    scriptfile=$(basename $scriptpath)
-   echo "scripts/$scriptfile etc/zabbix/scripts" >> debian/zabbix-agent.install
+   echo "zabbix-monitoring-scripts/scripts/$scriptfile etc/zabbix/scripts" >> debian/zabbix-agent.install
 done
 
 # Executable rights in post-install script
@@ -73,9 +76,9 @@ sed -i -e '/configure/a \    chmod 755 /etc/zabbix/scripts/*' debian/zabbix-agen
 # Monitoring script configuration files under /etc/zabbix/zabbix_agentd.d
 
 # Add each configuration file individually to files section
-for confpath in config/*; do
+for confpath in zabbix-monitoring-scripts/zabbix_agentd.d/*; do
    conffile=$(basename $confpath)
-   echo "config/$conffile etc/zabbix/zabbix_agentd.d" >> debian/zabbix-agent.install
+   echo "zabbix-monitoring-scripts/zabbix_agentd.d/$conffile etc/zabbix/zabbix_agentd.d" >> debian/zabbix-agent.install
 done
 
 # Add our packaging modifications in

--- a/rpm/Dockerfile.centos5
+++ b/rpm/Dockerfile.centos5
@@ -43,6 +43,6 @@ RUN chmod a+x /build.sh
 CMD /build.sh
 ENV ZABBIX_VERSION=3.2.3
 ENV ZABBIX_BRANCH=branch-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=0
+ENV PULSSI_RELEASE_VERSION=1
 ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.2/rhel/5/SRPMS/zabbix-3.2.3-1.el5.src.rpm
 ENV RPMBUILD=/usr/src/redhat

--- a/rpm/Dockerfile.centos6
+++ b/rpm/Dockerfile.centos6
@@ -19,6 +19,6 @@ RUN chmod a+x /build.sh
 CMD /build.sh
 ENV ZABBIX_VERSION=3.2.3
 ENV ZABBIX_BRANCH=branch-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=0
+ENV PULSSI_RELEASE_VERSION=1
 ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.2/rhel/6/SRPMS/zabbix-3.2.3-1.el6.src.rpm
 ENV RPMBUILD=/root/rpmbuild

--- a/rpm/Dockerfile.centos7
+++ b/rpm/Dockerfile.centos7
@@ -19,7 +19,7 @@ RUN chmod a+x /build.sh
 CMD /build.sh
 ENV ZABBIX_VERSION=3.2.3
 ENV ZABBIX_BRANCH=branch-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=0
+ENV PULSSI_RELEASE_VERSION=1
 ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.2/rhel/7/SRPMS/zabbix-3.2.3-1.el7.src.rpm
 ENV RPMBUILD=/root/rpmbuild
 

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -37,11 +37,13 @@ mv zabbix-$ZABBIX_VERSION.tar.gz $RPMBUILD/SOURCES/
 popd
 
 # Get Pulssi monitoring scripts
+mkdir -p /tmp/zabbix-monitoring-scripts
+pushd /tmp/zabbix-monitoring-scripts
 wget https://github.com/digiapulssi/zabbix-monitoring-scripts/tarball/master
-tar -zxvf master */scripts --strip 1
-tar -zxvf master */config --strip 1
+tar -zxvf master */etc/zabbix/scripts --strip 3
+tar -zxvf master */etc/zabbix/zabbix_agentd.d --strip 3
 tar cvf $RPMBUILD/SOURCES/scripts.tar.gz scripts
-pushd config
+cd zabbix_agentd.d
 tar cvf $RPMBUILD/SOURCES/scripts_config.tar.gz .
 popd
 

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -47,13 +47,22 @@ cd zabbix_agentd.d
 tar cvf $RPMBUILD/SOURCES/scripts_config.tar.gz .
 popd
 
-# Update SPEC contents
-# Add digiapulssi to the Release number
-#  Before change: Release part (including architcture) is 1.el6
-#  After change: Release part is 1.X.digiapulssi.el6
-#    X ($PULSSI_RELEASE_VERSION) defines Pulssi subversion number in case we want to release
-#                                multiple versions of a single Zabbix Agent version&release
-sed -i 's/^\(Release:\s\+[0-9]\+\)%{?alphatag:\.%{alphatag}}%{?dist}$/\1.'${PULSSI_RELEASE_VERSION}'.digiapulssi%{?dist}/' $RPMBUILD/SPECS/zabbix.spec
+
+##############################################################33
+# Update package name and version to SPEC
+
+# Change name from zabbix-agent to zabbix-agent-pulssi
+sed -i 's/^%package agent$/%package agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+# TBD ADD for Digia Pulssi to description
+sed -i 's/^%description agent$/%description agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^%pre agent$/%pre agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^%post agent$/%post agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^%preun agent$/%preun agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^%postun agent$/%postun agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^%files agent$/%files agent-pulssi/' $RPMBUILD/SPECS/zabbix.spec
+
+# Change release/build number (3.2.3-X where X is build number)
+sed -i 's/^\(Release:\s\+\)[0-9]\+%/\1'${PULSSI_RELEASE_VERSION}'%/' $RPMBUILD/SPECS/zabbix.spec
 
 ##############################################################33
 # Monitoring scripts under /etc/zabbix/scripts


### PR DESCRIPTION
* Updates required of zabbix-monitoring-scripts changes
* Copied docker-host-monitoring version from docker-host-monitoring branch that will be deleted after this merge -> the installation package can be downloaded directly from zabbix-agent release instead of keeping .deb package in docker-zabbix-agent repository
* Incremented pulssi version number from 3.2.3-1.0 to 3.2.3-1.1

Pre-release containing the built installation packages is here: https://github.com/digiapulssi/zabbix-agent/releases