### PR TITLE
Dockerfile for Debian Buster

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -45,16 +45,18 @@ popd
 pushd debian
 
 # First build the package creation containers locally
-docker build -t zabbix-deb:debian7 -f Dockerfile.debian7 .
+#docker build -t zabbix-deb:debian7 -f Dockerfile.debian7 .
 docker build -t zabbix-deb:debian8 -f Dockerfile.debian8 .
 docker build -t zabbix-deb:debian9 -f Dockerfile.debian9 .
-docker build -t zabbix-deb:debian8docker -f Dockerfile.debian8.docker-host-monitoring .
+docker build -t zabbix-deb:debian10 -f Dockerfile.debian10 .
+#docker build -t zabbix-deb:debian8docker -f Dockerfile.debian8.docker-host-monitoring .
 
 # Then run the following commands to produce new installation packages for different platforms
-docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian7
+#docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian7
 docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian8
 docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian9
-docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian8docker
+docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian10
+#docker run --rm -v $(pwd)/DEB:/DEB zabbix-deb:debian8docker
 
 popd
 

--- a/debian/Dockerfile.debian10
+++ b/debian/Dockerfile.debian10
@@ -1,15 +1,16 @@
-FROM debian:9
+FROM debian:buster
 
 # Zabbix agent build prerequisites
-RUN apt-get update && apt-get install -y build-essential devscripts quilt
-RUN apt-get install -y git autoconf autoconf automake wget unzip gcc pkg-config
+RUN apt-get update
+RUN apt-get install -y build-essential devscripts quilt
+RUN apt-get install -y git autoconf autoconf automake wget unzip gcc pkg-config rename
 
 # Required for Zabbix tarball compiling
 RUN apt-get install -y ruby rubygems
 RUN gem install sass --version '=3.4.22'
 
 # Required by packaging that builds Zabbix server and proxy in addition to the agent
-RUN apt-get install -y libsnmp-dev default-libmysqlclient-dev libpq-dev libsqlite3-dev libcurl4-openssl-dev libssl-dev libldap2-dev libiksemel-dev libopenipmi-dev libssh2-1-dev unixodbc-dev openjdk-8-jdk libxml2-dev
+RUN apt-get install -y libsnmp-dev default-libmysqlclient-dev libpq-dev libsqlite3-dev libcurl4-openssl-dev libssl-dev libldap2-dev libiksemel-dev libopenipmi-dev libssh2-1-dev unixodbc-dev openjdk-11-jdk libxml2-dev
 
 # Additional dependencies by Zabbix version 3.4
 RUN apt-get install -y libpcre++-dev libevent-dev
@@ -21,5 +22,5 @@ RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
 ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=1
+ENV PULSSI_RELEASE_VERSION=1+buster
 ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.10-1+stretch.dsc

--- a/debian/Dockerfile.debian7
+++ b/debian/Dockerfile.debian7
@@ -19,7 +19,7 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=5
-ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.4-4+wheezy.dsc
+ENV PULSSI_RELEASE_VERSION=1
+ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.10-1+wheezy.dsc

--- a/debian/Dockerfile.debian8
+++ b/debian/Dockerfile.debian8
@@ -19,7 +19,7 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=5
-ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.4-4+jessie.dsc
+ENV PULSSI_RELEASE_VERSION=1
+ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.10-1+jessie.dsc

--- a/debian/Dockerfile.debian8.docker-host-monitoring
+++ b/debian/Dockerfile.debian8.docker-host-monitoring
@@ -19,7 +19,7 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD ["/bin/bash", "/build.sh"]
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-docker-host-monitoring
-ENV PULSSI_RELEASE_VERSION=5.docker-host-monitoring
-ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.4-4+jessie.dsc
+ENV PULSSI_RELEASE_VERSION=1.docker-host-monitoring
+ENV URL_ZABBIX_DSC http://repo.zabbix.com/zabbix/3.4/debian/pool/main/z/zabbix/zabbix_3.4.10-1+jessie.dsc

--- a/rpm/Dockerfile.centos5
+++ b/rpm/Dockerfile.centos5
@@ -44,10 +44,10 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD /build.sh
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=5
-ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/5/SRPMS/zabbix-3.4.4-2.el5.src.rpm
+ENV PULSSI_RELEASE_VERSION=1
+ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/5/SRPMS/zabbix-3.4.10-1.el5.src.rpm
 ENV RPMBUILD=/usr/src/redhat
 
 # RH/CentOS 5 does not have jq package at all

--- a/rpm/Dockerfile.centos6
+++ b/rpm/Dockerfile.centos6
@@ -24,10 +24,10 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD /build.sh
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=5
-ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/6/SRPMS/zabbix-3.4.4-2.el6.src.rpm
+ENV PULSSI_RELEASE_VERSION=1
+ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/6/SRPMS/zabbix-3.4.10-1.el6.src.rpm
 ENV RPMBUILD=/root/rpmbuild
 ENV JQ_DEPENDENCY=true
 

--- a/rpm/Dockerfile.centos7
+++ b/rpm/Dockerfile.centos7
@@ -1,7 +1,7 @@
 FROM centos:7
 
 # Zabbix agent build prerequisites
-RUN yum install -y git autoconf autoheader automake wget unzip gcc glibc-static
+RUN yum install -y git autoconf autoheader automake wget unzip gcc glibc-static rename
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 RUN yum install -y rpm-build fedora-packager
 
@@ -24,9 +24,9 @@ WORKDIR /build
 COPY build.sh /build.sh
 RUN chmod a+x /build.sh
 CMD /build.sh
-ENV ZABBIX_VERSION=3.4.4
+ENV ZABBIX_VERSION=3.4.10
 ENV ZABBIX_BRANCH=pulssi-$ZABBIX_VERSION
-ENV PULSSI_RELEASE_VERSION=5
-ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/7/SRPMS/zabbix-3.4.4-2.el7.src.rpm
+ENV PULSSI_RELEASE_VERSION=1
+ENV URL_ZABBIX_SRPM http://repo.zabbix.com/zabbix/3.4/rhel/7/SRPMS/zabbix-3.4.10-1.el7.src.rpm
 ENV RPMBUILD=/root/rpmbuild
 ENV JQ_DEPENDENCY=true


### PR DESCRIPTION
- Dockerfile for Debian Buster.
- Zabbix version 3.4.10.
- Commented out Debian 7 (LTS is EOL, see https://www.debian.org/News/2018/20180601 for details).
- Commented out Debian 8 docker-host-monitoring.
